### PR TITLE
[Fix] 구글메타태그,네이버메타태그 verfication 객체로 변경

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -76,6 +76,12 @@ export const metadata: Metadata = {
     locale: 'ko_KR',
     type: 'website',
   },
+  verification: {
+    google: 'fiC0NU8DxxzXEcRLCPDuncxNkJEWxTMjFu1yzgrWWBc',
+    other: {
+      naverSiteVerification: 'ebfa31257c992ba72b96c652b1294f1c4777c1d2',
+    },
+  },
 };
 
 export default async function RootLayout({
@@ -89,14 +95,6 @@ export default async function RootLayout({
       className={`${GmarketSansBold.variable} ${GmarketSansMedium.variable} ${GmarketSansLight.variable} ${PretendardSemiBold.variable} ${PretendardLight.variable} ${PretendardMedium.variable} ${PretendardRegular.variable} ${PretendardExtraLight.variable} ${PretendardBold.variable}`}
     >
       <head>
-        <meta
-          name="naver-site-verification"
-          content="ebfa31257c992ba72b96c652b1294f1c4777c1d2"
-        />
-        <meta
-          name="google-site-verification"
-          content="fiC0NU8DxxzXEcRLCPDuncxNkJEWxTMjFu1yzgrWWBc"
-        />
         <link rel="icon" href="/favicon.ico" sizes="any" />
         <noscript>
           <img


### PR DESCRIPTION
# 🔥 Pull requests

### 🌴 작업한 브랜치

- #234 

### ✅ 작업한 내용

- head 태그 안에 있던 구글서치콘솔메타태그, 네이버 웹마스터 메타태그를 const metadata 변수안으로 넣어줬습니다.

### ❗️PR Point

```jsx
export const metadata: Metadata = {
  title: 'fitapat(핏어팻)',
  description: '반려동물과 당신만의 설렘을 포장합니다',
  openGraph: {
    title: 'fitapat(핏어팻)',
    description: '반려동물과 당신만의 설렘을 포장합니다',
    url: 'https://www.fitapat.com/',
    siteName: 'fitapat(핏어팻)',
    images: [
      {
        url: 'https://velog.velcdn.com/images/imphj3/post/ea94be96-de31-480c-a91a-2d0f887f6b91/image.png',
        width: 800,
        height: 400,
      },
    ],
    locale: 'ko_KR',
    type: 'website',
  },
  verification: {
    google: 'fiC0NU8DxxzXEcRLCPDuncxNkJEWxTMjFu1yzgrWWBc',
    other: {
      naverSiteVerification: 'ebfa31257c992ba72b96c652b1294f1c4777c1d2',
    },
  },
};
```

### 📸 스크린샷

closed #
