### PR TITLE
[FIx] Description에서도 title 표기(#264)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,10 +60,10 @@ const GmarketSansLight = localFont({
 
 export const metadata: Metadata = {
   title: 'fitapat(핏어팻)',
-  description: '반려동물과 당신만의 설렘을 포장합니다',
+  description: '반려동물과 당신만의 설렘을 포장합니다 | fitapat(핏어팻)',
   openGraph: {
     title: 'fitapat(핏어팻)',
-    description: '반려동물과 당신만의 설렘을 포장합니다',
+    description: '반려동물과 당신만의 설렘을 포장합니다 | fitapat(핏어팻)',
     url: 'https://www.fitapat.com/',
     siteName: 'fitapat(핏어팻)',
     images: [


### PR DESCRIPTION
# 🔥 Pull requests

### 🌴 작업한 브랜치

- #264 

### ✅ 작업한 내용

- 구글 seo에서 설정한 description을 탐색하지 못하는 문제가 있어 해결했습니다.

### ❗️PR Point

description에서 title에 있는 문구를 포함했습니다.
주로 검색되는 fitapat , 핏어팻이 기존에 description에 포함되어 있지 않아 메인 페이지 중 핏어팻이라는 글자가 있는 부분이 노출이 되었던 것 같습니다.
<img width="559" alt="image" src="https://github.com/TeamZOOC/ZOOC-STORE/assets/69576360/ca751a94-27ca-4722-aa26-b9c1b5a49713">

`description: '반려동물과 당신만의 설렘을 포장합니다 | fitapat(핏어팻)',`

### 📸 스크린샷

closed #이슈번호

[구글 검색엔진 SEO](https://velog.io/@w-hyacinth/%EA%B2%80%EC%83%89%EC%97%94%EC%A7%84SEO%EC%97%90-%EB%82%B4%EA%B0%80-%EC%84%A4%EC%A0%95%ED%95%9C-meta-description%EA%B3%BC-%EB%8B%A4%EB%A5%B4%EA%B2%8C-%EB%85%B8%EC%B6%9C%EB%90%98%EB%8A%94-%EC%82%AC%EB%A1%80-Google)